### PR TITLE
ContextualTextureRenderer: Add separate method for tiled drawing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "io.github.juuxel"
-version = "1.1.0"
+version = "1.2.0-beta.1"
 
 val demoSources = sourceSets.create("demo")
 

--- a/src/main/java/juuxel/libninepatch/ContextualTextureRenderer.java
+++ b/src/main/java/juuxel/libninepatch/ContextualTextureRenderer.java
@@ -54,4 +54,77 @@ public interface ContextualTextureRenderer<T, C> {
         v2 = NinePatch.lerp(v2, region.v1, region.v2);
         draw(texture, context, x, y, width, height, u1, v1, u2, v2);
     }
+
+    /**
+     * Draws a tiled rectangular subregion of a texture.
+     *
+     * <p>The default implementation uses {@link #draw(Object, Object, int, int, int, int, float, float, float, float) draw()}
+     * to draw each tile, but implementations may want to override this method for more performant rendering.
+     *
+     * @param texture      the texture
+     * @param context      the context needed to draw the texture
+     * @param x            the leftmost X coordinate of the target drawing region
+     * @param y            the topmost Y coordinate of the target drawing region
+     * @param regionWidth  the total width of the target region
+     * @param regionHeight the total height of the target region
+     * @param tileWidth    the width of an individual tile in the target region
+     * @param tileHeight   the height of an individual tile in the target region
+     * @param u1           the left edge of the input region as a fraction from 0 to 1
+     * @param v1           the top edge of the input region as a fraction from 0 to 1
+     * @param u2           the right edge of the input region as a fraction from 0 to 1
+     * @param v2           the bottom edge of the input region as a fraction from 0 to 1
+     * @since 1.2.0
+     */
+    default void drawTiled(T texture, C context, int x, int y, int regionWidth, int regionHeight, int tileWidth, int tileHeight, float u1, float v1, float u2, float v2) {
+        int widthRemaining = regionWidth;
+        int currentX = x;
+
+        while (widthRemaining > 0) {
+            int tw = Math.min(widthRemaining, tileWidth);
+            widthRemaining -= tw;
+            float tu2 = tw == tileWidth ? u2 : NinePatch.lerp((float) tw / (float) tileWidth, u1, u2);
+
+            int heightRemaining = regionHeight;
+            int currentY = y;
+
+            while (heightRemaining > 0) {
+                int th = Math.min(heightRemaining, tileHeight);
+                heightRemaining -= th;
+                float tv2 = th == tileHeight ? v2 : NinePatch.lerp((float) th / (float) tileHeight, v1, v2);
+                draw(texture, context, currentX, currentY, tw, th, u1, v1, tu2, tv2);
+                currentY += th;
+            }
+
+            currentX += tw;
+        }
+    }
+
+    /**
+     * Draws a tiled rectangular subregion of a texture.
+     *
+     * <p>The default implementation delegates to {@linkplain #drawTiled(Object, Object, int, int, int, int, int, int, float, float, float, float)
+     * the overload taking a raw {@code T} texture}; generally only that overload should be overridden.
+     *
+     * @param region       the texture region
+     * @param context      the context needed to draw the texture
+     * @param x            the leftmost X coordinate of the target drawing region
+     * @param y            the topmost Y coordinate of the target drawing region
+     * @param regionWidth  the total width of the target region
+     * @param regionHeight the total height of the target region
+     * @param tileWidth    the width of an individual tile in the target region
+     * @param tileHeight   the height of an individual tile in the target region
+     * @param u1           the left edge of the input region as a fraction from 0 to 1
+     * @param v1           the top edge of the input region as a fraction from 0 to 1
+     * @param u2           the right edge of the input region as a fraction from 0 to 1
+     * @param v2           the bottom edge of the input region as a fraction from 0 to 1
+     * @since 1.2.0
+     */
+    default void drawTiled(TextureRegion<? extends T> region, C context, int x, int y, int regionWidth, int regionHeight, int tileWidth, int tileHeight, float u1, float v1, float u2, float v2) {
+        T texture = region.texture;
+        u1 = NinePatch.lerp(u1, region.u1, region.u2);
+        u2 = NinePatch.lerp(u2, region.u1, region.u2);
+        v1 = NinePatch.lerp(v1, region.v1, region.v2);
+        v2 = NinePatch.lerp(v2, region.v1, region.v2);
+        drawTiled(texture, context, x, y, regionWidth, regionHeight, tileWidth, tileHeight, u1, v1, u2, v2);
+    }
 }

--- a/src/main/java/juuxel/libninepatch/NinePatch.java
+++ b/src/main/java/juuxel/libninepatch/NinePatch.java
@@ -91,29 +91,13 @@ public final class NinePatch<T> {
 
         // Middle
         {
-            int widthRemaining = width - 2 * cornerWidth;
-            int x = cornerWidth;
-
-            while (widthRemaining > 0) {
-                int tw = Math.min(widthRemaining, tileWidth);
-                widthRemaining -= tw;
-                float tu2 = tw == tileWidth ? u2 : lerp((float) tw / (float) tileWidth, u1, u2);
-
-                int heightRemaining = height - 2 * cornerHeight;
-                int y = cornerHeight;
-
-                while (heightRemaining > 0) {
-                    int th = Math.min(heightRemaining, tileHeight);
-                    heightRemaining -= th;
-                    float tv2 = th == tileHeight ? v2 : lerp((float) th / (float) tileHeight, v1, v2);
-
-                    renderer.draw(texture, context, x, y, tw, th, u1, v1, tu2, tv2);
-
-                    y += th;
-                }
-
-                x += tw;
-            }
+            renderer.drawTiled(
+                texture, context,
+                cornerWidth, cornerHeight,
+                width - 2 * cornerWidth, height - 2 * cornerHeight,
+                tileWidth, tileHeight,
+                u1, v1, u2, v2
+            );
         }
 
         if (hasCorners()) {
@@ -121,36 +105,18 @@ public final class NinePatch<T> {
 
             // vertical
             {
-                int heightRemaining = height - 2 * cornerHeight;
+                int regionHeight = height - 2 * cornerHeight;
                 int y = cornerHeight;
-
-                while (heightRemaining > 0) {
-                    int th = Math.min(heightRemaining, tileHeight);
-                    heightRemaining -= th;
-                    float tv2 = th == tileHeight ? v2 : lerp((float) th / (float) tileHeight, v1, v2);
-
-                    renderer.draw(texture, context, 0, y, cornerWidth, th, 0, v1, cornerU, tv2);
-                    renderer.draw(texture, context, width - cornerWidth, y, cornerWidth, th, 1 - cornerU, v1, 1, tv2);
-
-                    y += th;
-                }
+                renderer.drawTiled(texture, context, 0, y, cornerWidth, regionHeight, cornerWidth, tileHeight, 0, v1, cornerU, v2);
+                renderer.drawTiled(texture, context, width - cornerWidth, y, cornerWidth, regionHeight, cornerWidth, tileHeight, 1 - cornerU, v1, 1, v2);
             }
 
             // Horizontal
             {
-                int widthRemaining = width - 2 * cornerWidth;
+                int regionWidth = width - 2 * cornerWidth;
                 int x = cornerWidth;
-
-                while (widthRemaining > 0) {
-                    int tw = Math.min(widthRemaining, tileWidth);
-                    widthRemaining -= tw;
-                    float tu2 = tw == tileWidth ? u2 : lerp((float) tw / (float) tileWidth, u1, u2);
-
-                    renderer.draw(texture, context, x, 0, tw, cornerHeight, u1, 0, tu2, cornerV);
-                    renderer.draw(texture, context, x, height - cornerHeight, tw, cornerHeight, u1, 1 - cornerV, tu2, 1);
-
-                    x += tw;
-                }
+                renderer.drawTiled(texture, context, x, 0, regionWidth, cornerHeight, tileWidth, cornerHeight, u1, 0, u2, cornerV);
+                renderer.drawTiled(texture, context, x, height - cornerHeight, regionWidth, cornerHeight, tileWidth, cornerHeight, u1, 1 - cornerV, u2, 1);
             }
         }
     }


### PR DESCRIPTION
This allows real-time implementations such as LibGui to replace the renderer with a more performant one that only does a single OpenGL draw call and does the tiling in a shader etc.

cc @BlazingTwist